### PR TITLE
Changes to allow f2py handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ if (NOT CMAKE_BUILD_TYPE)
   esma_add_subdirectory(env)
   esma_add_subdirectory(src)
 
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+  if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+    file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+  endif()
+
 # Piggyback that file into install
 # --------------------------------
   install(

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.12.0
+  tag: v3.13.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,17 +5,17 @@ AeroML:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.2
+  tag: v3.13.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.7
+  tag: v3.12.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.0.6
+  tag: geos/v1.2.0
 

--- a/src/Shared/GMAOpyobs/CMakeLists.txt
+++ b/src/Shared/GMAOpyobs/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 # Python executables
 # ------------------  
-  install(PROGRAMS active_aeronet.py csBinner DESTINATION bin)
+  install(PROGRAMS active_aeronet.py csBinner.py DESTINATION bin)
 
 # TO DO: Convert these to pure python
 #        ext_sampler.py  stn_sampler.py stn_xsect.py  trj_sampler.py  trj_xsect.py 

--- a/src/Shared/GMAOpyobs/f2py/CMakeLists.txt
+++ b/src/Shared/GMAOpyobs/f2py/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Cmake rules for creating python modules with f2py and 
 #
 
-set ( this GMAOpyobs )
+esma_set_this ( OVERRIDE GMAOpyobs )
 
 # cmake requirements
 # ------------------

--- a/src/Shared/GMAOpyobs/f2py/CMakeLists.txt
+++ b/src/Shared/GMAOpyobs/f2py/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Cmake rules for creating python modules with f2py and 
 #
 
+# The OVERRIDE tells esma_set_this() to name the library as
+# what we set here rather than the name of the directory
 esma_set_this ( OVERRIDE GMAOpyobs )
 
 # cmake requirements

--- a/src/Shared/GMAOpyobs/f2py/VegType_io.c
+++ b/src/Shared/GMAOpyobs/f2py/VegType_io.c
@@ -6,6 +6,7 @@ routines from RAMS.
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 static FILE *file;
 


### PR DESCRIPTION
This PR makes some changes that were needed to build on both discover and on macOS (parcel).

The changes were tested with Intel-Clang and GNU on macOS and Intel on discover. 

The one C code change was due to an error from clang on macOS where it would not allow `exit(1)` without `#include <stdlib.h>` as `exit` is defined in `stdlib.h`. 