### PR TITLE
Update to ESMA_env v4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - updated GMAOpyobs to latest v1.0.5
+- Update to ESMA_env v4.8.2 (Fixes for RHEL8 GMAO Machines)
 
 ## [v1.0.0] 2023-06-07
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ AeroML:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.8.0
+  tag: v4.8.2
   develop: main
 
 cmake:


### PR DESCRIPTION
As found by @patricia-nasa, when calculon moved to RHEL8, Baselibs stopped working (as it was compiled for an older OS). This PR updates AeroML to use [ESMA_env v4.8.2](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.8.2) which has updates to allow RHEL8 GMAO compilation.

I do not know if this is zero-diff or not, so I label both until @patricia-nasa can test.